### PR TITLE
Fix the NPE that can occur when the LOINC is not annotated

### DIFF
--- a/src/main/java/org/monarchinitiative/fhir2hpo/service/ObservationAnalysisService.java
+++ b/src/main/java/org/monarchinitiative/fhir2hpo/service/ObservationAnalysisService.java
@@ -3,12 +3,14 @@ package org.monarchinitiative.fhir2hpo.service;
 import java.util.Set;
 
 import org.hl7.fhir.dstu3.model.Observation;
+import org.monarchinitiative.fhir2hpo.fhir.util.ObservationLoincInfo;
 import org.monarchinitiative.fhir2hpo.fhir.util.ObservationUtil;
 import org.monarchinitiative.fhir2hpo.hpo.LoincConversionResult;
 import org.monarchinitiative.fhir2hpo.hpo.ObservationConversionResult;
 import org.monarchinitiative.fhir2hpo.loinc.Loinc2HpoAnnotation;
 import org.monarchinitiative.fhir2hpo.loinc.LoincId;
 import org.monarchinitiative.fhir2hpo.loinc.exception.LoincNotAnnotatedException;
+import org.monarchinitiative.fhir2hpo.loinc.exception.MismatchedLoincIdException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -29,12 +31,19 @@ public class ObservationAnalysisService {
 		
 		Set<LoincId> loincIds = ObservationUtil.getAllLoincIdsOfObservation(observation);
 		for (LoincId loincId : loincIds) {
-			LoincConversionResult loincResult = new LoincConversionResult(null);
+			LoincConversionResult loincResult = null;
 			try {
 				Loinc2HpoAnnotation annotation = annotationService.getAnnotations(loincId);
 				loincResult = annotation.convert(observation);
 			} catch (LoincNotAnnotatedException e) {
-				loincResult.setException(e);
+				try {
+					// Save the ObservationLoincInfo and set an exception on the result
+					ObservationLoincInfo loincInfo = new ObservationLoincInfo(loincId, observation);
+					loincResult = new LoincConversionResult(loincInfo);
+					loincResult.setException(e);
+				} catch (MismatchedLoincIdException ex) {
+					// We've already established that the Observation contains the LOINC, so this can't happen
+				}
 			}
 			result.addLoincConversionResult(loincResult);
 		}


### PR DESCRIPTION
The LoincConversionResult did not always have a LoincId since I constructed it by passing a null parameter before. It's now constructed properly so the NullPointerException is no longer thrown.