### PR TITLE
Fix NPE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>1.8</java.version>
-		<phenol.version>1.2.2</phenol.version>
+		<phenol.version>1.2.4</phenol.version>
 	</properties>
 
 	<dependencies>

--- a/src/main/java/org/monarchinitiative/fhir2hpo/hpo/LoincConversionResult.java
+++ b/src/main/java/org/monarchinitiative/fhir2hpo/hpo/LoincConversionResult.java
@@ -10,41 +10,52 @@ import org.monarchinitiative.fhir2hpo.loinc.LoincId;
 
 /**
  * This encapsulates the result of attempting to convert a LOINC to an HPO Term. This includes
- * the observation information specific to the LOINC and the results of each method tried.
+ * the observation information specific to the LOINC and the results of each method tried. 
  * 
  * @author yateam
  *
  */
 public class LoincConversionResult {
 
-	final ObservationLoincInfo observationLoincInfo;
-
-	Exception exception; // An exception may be thrown before any methods have been tried
+	private final LoincId loincId;
+	private ObservationLoincInfo observationLoincInfo;
+	
+	// An exception may be thrown before any methods have been tried
+	Exception exception; 
 
 	// A map from the method description to the specific result for that method.
 	Map<String, MethodConversionResult> methods = new HashMap<>();
 
-	public LoincConversionResult(ObservationLoincInfo observationLoincInfo) {
+	public LoincConversionResult(LoincId loincId) {
+		this.loincId = loincId;
+	}
+	
+	/**
+	 * Set the observation information specific to the LOINC.
+	 * @param observationLoincInfo
+	 */
+	public void setObservationLoincInfo(ObservationLoincInfo observationLoincInfo) {
 		this.observationLoincInfo = observationLoincInfo;
 	}
 
 	/**
 	 * Get the observation information specific to the LOINC
 	 * 
-	 * @return the relevant observation information for the LOINC
+	 * @return the relevant observation information for the LOINC. This may be null if an exception is thrown
+	 * before it can be set.
 	 */
 	public ObservationLoincInfo getObservationLoincInfo() {
 		return observationLoincInfo;
 	}
 
 	/**
-	 * Get the relevant loincId for this result from the observation. Some observations may have more
-	 * than one LoincId, yielding multiple conversion results.
+	 * Get the relevant loincId for this result. Some observations may have more than one LoincId, yielding 
+	 * multiple conversion results.
 	 * 
-	 * @return the relevant loincId for this result or null if none exists.
+	 * @return the relevant loincId for this result
 	 */
 	public LoincId getLoincId() {
-		return observationLoincInfo.getLoincId();
+		return loincId;
 	}
 
 	/**

--- a/src/main/java/org/monarchinitiative/fhir2hpo/loinc/DefaultLoinc2HpoAnnotation.java
+++ b/src/main/java/org/monarchinitiative/fhir2hpo/loinc/DefaultLoinc2HpoAnnotation.java
@@ -131,11 +131,11 @@ public class DefaultLoinc2HpoAnnotation implements Loinc2HpoAnnotation {
 	@Override
 	public LoincConversionResult convert(Observation observation) {
 		
-		LoincConversionResult result = new LoincConversionResult(null);
+		LoincConversionResult result = new LoincConversionResult(loincId);
 		try {
 			
 			ObservationLoincInfo observationLoincInfo = new ObservationLoincInfo(loincId, observation);
-			result = new LoincConversionResult(observationLoincInfo);
+			result.setObservationLoincInfo(observationLoincInfo);
 			
 			result.addMethodConversionResult(convertInterpretation(observationLoincInfo.getInterpretation()));
 			result.addMethodConversionResult(convertValueQuantity(observationLoincInfo.getValueQuantity(), observationLoincInfo.getReferenceRange()));

--- a/src/main/java/org/monarchinitiative/fhir2hpo/loinc/NonInterpretableLoincAnnotation.java
+++ b/src/main/java/org/monarchinitiative/fhir2hpo/loinc/NonInterpretableLoincAnnotation.java
@@ -47,7 +47,7 @@ public class NonInterpretableLoincAnnotation implements Loinc2HpoAnnotation {
 
 	@Override
 	public LoincConversionResult convert(Observation observation) {
-		LoincConversionResult result = new LoincConversionResult(null);
+		LoincConversionResult result = new LoincConversionResult(loincId);
 		result.setException(new NonInterpretableLoincException(reason));
 		return result;
 	}

--- a/src/main/java/org/monarchinitiative/fhir2hpo/service/ObservationAnalysisService.java
+++ b/src/main/java/org/monarchinitiative/fhir2hpo/service/ObservationAnalysisService.java
@@ -3,14 +3,12 @@ package org.monarchinitiative.fhir2hpo.service;
 import java.util.Set;
 
 import org.hl7.fhir.dstu3.model.Observation;
-import org.monarchinitiative.fhir2hpo.fhir.util.ObservationLoincInfo;
 import org.monarchinitiative.fhir2hpo.fhir.util.ObservationUtil;
 import org.monarchinitiative.fhir2hpo.hpo.LoincConversionResult;
 import org.monarchinitiative.fhir2hpo.hpo.ObservationConversionResult;
 import org.monarchinitiative.fhir2hpo.loinc.Loinc2HpoAnnotation;
 import org.monarchinitiative.fhir2hpo.loinc.LoincId;
 import org.monarchinitiative.fhir2hpo.loinc.exception.LoincNotAnnotatedException;
-import org.monarchinitiative.fhir2hpo.loinc.exception.MismatchedLoincIdException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -36,14 +34,8 @@ public class ObservationAnalysisService {
 				Loinc2HpoAnnotation annotation = annotationService.getAnnotations(loincId);
 				loincResult = annotation.convert(observation);
 			} catch (LoincNotAnnotatedException e) {
-				try {
-					// Save the ObservationLoincInfo and set an exception on the result
-					ObservationLoincInfo loincInfo = new ObservationLoincInfo(loincId, observation);
-					loincResult = new LoincConversionResult(loincInfo);
-					loincResult.setException(e);
-				} catch (MismatchedLoincIdException ex) {
-					// We've already established that the Observation contains the LOINC, so this can't happen
-				}
+				loincResult = new LoincConversionResult(loincId);
+				loincResult.setException(e);
 			}
 			result.addLoincConversionResult(loincResult);
 		}


### PR DESCRIPTION
Redesign for results where LOINC is known but exception occurs before observation is parsed. 

Once this bug fix is merged, I think it will be a good time to release version 1.0.0 of the library. In the next couple of weeks, I'll follow up with additional work on panels, but this is a natural stopping point for a deployed artifact.